### PR TITLE
Support slot-only remote --slot specifications

### DIFF
--- a/lib/remote-socket.c
+++ b/lib/remote-socket.c
@@ -93,8 +93,15 @@ remote_parse_slot(struct remote_ctx *ctx, struct pci_access *a, const char *spec
   char *err = pci_filter_parse_slot(&filter, slot_part);
   if (err)
     a->error("Invalid remote slot specification: %s", err);
-  if (filter.domain < 0 || filter.bus < 0 || filter.slot < 0 || filter.func < 0)
-    a->error("Remote slot requires full domain:bus:slot.func specification");
+
+  if (filter.slot < 0)
+    a->error("Remote slot specification must include a slot number");
+  if (filter.domain < 0)
+    filter.domain = 0;
+  if (filter.bus < 0)
+    filter.bus = 0;
+  if (filter.func < 0)
+    filter.func = 0;
 
   ctx->domain = filter.domain;
   ctx->bus = filter.bus;

--- a/lspci.c
+++ b/lspci.c
@@ -41,6 +41,19 @@ static struct pci_filter remote_slot_filter;
 static int remote_slot_enabled;
 
 static void
+normalize_remote_slot_filter(struct pci_filter *f)
+{
+  if (f->slot < 0)
+    die("--slot requires a slot number");
+  if (f->domain < 0)
+    f->domain = 0;
+  if (f->bus < 0)
+    f->bus = 0;
+  if (f->func < 0)
+    f->func = 0;
+}
+
+static void
 consume_remote_slot_option(int *argc, char ***argvp)
 {
   char **argv = *argvp;
@@ -1194,6 +1207,7 @@ main(int argc, char **argv)
       pci_filter_init(pacc, &tmp);
       if (msg = pci_filter_parse_slot(&tmp, opt_remote_slot_bdf))
         die("--slot: %s", msg);
+      normalize_remote_slot_filter(&tmp);
       remote_slot_filter = tmp;
       remote_slot_enabled = 1;
       filter = tmp;

--- a/lspci.man
+++ b/lspci.man
@@ -173,8 +173,9 @@ option to select a different domain.
 .TP
 .B --slot [<host>[:<port>]@]<slot>
 Forward configuration space accesses for the specified slot to a remote
-management controller reachable over TCP. The slot must be provided as a
-complete \fIdomain:bus:device.function\fP tuple. When the optional host (and
+management controller reachable over TCP. The slot may be provided as either a
+simple slot number or a complete \fIdomain:bus:device.function\fP tuple. Any
+unspecified domain, bus, or function components default to zero. When the optional host (and
 port) part is omitted, the utility derives the remote address from the local
 IPv4 assignment: it expects the machine running \fIlspci\fP to own the address
 \fB192.168.<bus>.1<device>\fP and connects to \fB192.168.<bus>.<device>\fP on

--- a/setpci.c
+++ b/setpci.c
@@ -60,6 +60,19 @@ static struct pci_filter remote_slot_filter;
 static int remote_slot_enabled;
 
 static void
+normalize_remote_slot_filter(struct pci_filter *f)
+{
+  if (f->slot < 0)
+    die("--slot requires a slot number");
+  if (f->domain < 0)
+    f->domain = 0;
+  if (f->bus < 0)
+    f->bus = 0;
+  if (f->func < 0)
+    f->func = 0;
+}
+
+static void
 consume_remote_slot_option(int *argc, char ***argvp)
 {
   char **argv = *argvp;
@@ -910,6 +923,7 @@ main(int argc, char **argv)
       pci_filter_init(pacc, &tmp);
       if (msg = pci_filter_parse_slot(&tmp, remote_slot_bdf))
         die("--slot: %s", msg);
+      normalize_remote_slot_filter(&tmp);
       remote_slot_filter = tmp;
       remote_slot_enabled = 1;
     }

--- a/setpci.man
+++ b/setpci.man
@@ -66,8 +66,9 @@ used stand-alone.
 .TP
 .B --slot [<host>[:<port>]@]<slot>
 Forward all configuration space accesses to the specified slot through a
-remote management controller. The slot string must include the complete
-\fIdomain:bus:device.function\fP tuple. When the host (and optional port)
+remote management controller. The slot string may be a simple slot number or a
+complete \fIdomain:bus:device.function\fP tuple. Any unspecified domain, bus,
+or function values default to zero. When the host (and optional port)
 portion is omitted the controller address is derived from the local IPv4
 configuration: \fIsetpci\fP expects to own \fB192.168.<bus>.1<device>\fP and
 will contact \fB192.168.<bus>.<device>\fP on port 4001.


### PR DESCRIPTION
## Summary
- default missing domain, bus, and function values when parsing remote --slot specifications
- normalize remote slot filters in lspci and setpci so slot-only values work with existing filtering logic
- document the relaxed --slot syntax in the lspci and setpci man pages

## Testing
- make

------
https://chatgpt.com/codex/tasks/task_e_68d8835431a48325b3eabcf4c152594c