### PR TITLE
Support slot identifiers for pcilmr

### DIFF
--- a/lmr/lmr.h
+++ b/lmr/lmr.h
@@ -195,14 +195,14 @@ bool margin_find_pair(struct pci_access *pacc, struct pci_dev *dev, struct pci_d
                       struct pci_dev **up_port);
 
 /* Verify that devices form the link with 16 GT/s or 32 GT/s data rate */
-bool margin_verify_link(struct pci_dev *down_port, struct pci_dev *up_port);
+bool margin_verify_link(struct pci_dev *down_port, struct pci_dev *up_port, bool skip_role_check);
 
 /* Check Margining Ready bit from Margining Port Status Register */
 bool margin_check_ready_bit(struct pci_dev *dev);
 
 /* Verify link and fill wrappers */
 bool margin_fill_link(struct pci_dev *down_port, struct pci_dev *up_port,
-                      struct margin_link *wrappers);
+                      struct margin_link *wrappers, bool skip_role_check);
 
 /* Disable ASPM, set Hardware Autonomous Speed/Width Disable bits */
 bool margin_prep_link(struct margin_link *link);

--- a/lmr/margin.c
+++ b/lmr/margin.c
@@ -457,7 +457,7 @@ margin_read_params(struct pci_access *pacc, struct pci_dev *dev, u8 recvn,
   if (!margin_find_pair(pacc, dev, &down, &up))
     return false;
 
-  if (!margin_fill_link(down, up, &link))
+  if (!margin_fill_link(down, up, &link, false))
     return false;
 
   struct margin_dev *dut = (dev_down ? &link.down_port : &link.up_port);

--- a/lmr/margin_args.c
+++ b/lmr/margin_args.c
@@ -37,8 +37,37 @@ const char *usage
     "-v <steps>\t\tSpecify maximum number of steps for Voltage Margining.\n";
 
 static struct pci_dev *
-dev_for_filter(struct pci_access *pacc, char *filter)
+dev_for_filter(struct pci_access *pacc, char *filter, bool *skip_role_check)
 {
+  *skip_role_check = false;
+
+  if (!strncmp(filter, "slot", 4) && filter[4])
+    {
+      char *slot = filter + 4;
+      struct pci_dev *match = NULL;
+
+      for (struct pci_dev *p = pacc->devices; p; p = p->next)
+        {
+          pci_fill_info(p, PCI_FILL_PHYS_SLOT);
+          if (!p->phy_slot)
+            continue;
+
+          if (!strcmp(p->phy_slot, filter) || !strcmp(p->phy_slot, slot)
+              || (!strncmp(p->phy_slot, "slot", 4) && !strcmp(p->phy_slot + 4, slot)))
+            {
+              match = p;
+              if (margin_port_is_down(p))
+                break;
+            }
+        }
+
+      if (!match)
+        die("No such PCI slot: %s or you don't have enough privileges.\n", filter);
+
+      *skip_role_check = true;
+      return match;
+    }
+
   struct pci_filter pci_filter;
   pci_filter_init(pacc, &pci_filter);
   if (pci_filter_parse_slot(&pci_filter, filter))
@@ -85,11 +114,11 @@ find_ready_links(struct pci_access *pacc, struct margin_link *links, bool cnt_on
           struct pci_dev *up = NULL;
           margin_find_pair(pacc, p, &down, &up);
 
-          if (down && margin_verify_link(down, up)
+          if (down && margin_verify_link(down, up, false)
               && (margin_check_ready_bit(down) || margin_check_ready_bit(up)))
             {
               if (!cnt_only)
-                margin_fill_link(down, up, &(links[cnt]));
+                margin_fill_link(down, up, &(links[cnt]), false);
               cnt++;
             }
         }
@@ -269,7 +298,8 @@ margin_parse_util_args(struct pci_access *pacc, int argc, char **argv, enum marg
     {
       while (optind != argc)
         {
-          struct pci_dev *dev = dev_for_filter(pacc, argv[optind]);
+          bool skip_role_check;
+          struct pci_dev *dev = dev_for_filter(pacc, argv[optind], &skip_role_check);
           optind++;
           links = xrealloc(links, (ports_n + 1) * sizeof(*links));
           struct pci_dev *down;
@@ -280,7 +310,7 @@ margin_parse_util_args(struct pci_access *pacc, int argc, char **argv, enum marg
           if (!cap)
             die("Looks like you don't have enough privileges to access "
                 "Device Configuration Space.\nTry to run utility as root.\n");
-          if (!margin_fill_link(down, up, &(links[ports_n])))
+          if (!margin_fill_link(down, up, &(links[ports_n]), skip_role_check))
             {
               margin_gen_bdfs(down, up, err, sizeof(err));
               die("Link %s is not ready for margining.\n"

--- a/lmr/margin_hw.c
+++ b/lmr/margin_hw.c
@@ -80,7 +80,7 @@ margin_find_pair(struct pci_access *pacc, struct pci_dev *dev, struct pci_dev **
 }
 
 bool
-margin_verify_link(struct pci_dev *down_port, struct pci_dev *up_port)
+margin_verify_link(struct pci_dev *down_port, struct pci_dev *up_port, bool skip_role_check)
 {
   struct pci_cap *cap = pci_find_cap(down_port, PCI_CAP_ID_EXP, PCI_CAP_NORMAL);
   if (!cap)
@@ -92,9 +92,10 @@ margin_verify_link(struct pci_dev *down_port, struct pci_dev *up_port)
 
   u8 down_sec = pci_read_byte(down_port, PCI_SECONDARY_BUS);
 
-  // Verify that devices are linked, down_port is Root Port or Downstream Port of Switch,
-  // up_port is Function 0 of a Device
-  if (!(down_sec == up_port->bus && margin_port_is_down(down_port) && up_port->func == 0))
+  // Verify that devices are linked. Optionally enforce that down_port is Root/Downstream Port
+  // and up_port is Function 0 of a Device.
+  if (!(down_sec == up_port->bus
+        && (skip_role_check || (margin_port_is_down(down_port) && up_port->func == 0))))
     return false;
 
   struct pci_cap *pm = pci_find_cap(up_port, PCI_CAP_ID_PM, PCI_CAP_NORMAL);
@@ -128,10 +129,11 @@ fill_dev_wrapper(struct pci_dev *dev)
 }
 
 bool
-margin_fill_link(struct pci_dev *down_port, struct pci_dev *up_port, struct margin_link *wrappers)
+margin_fill_link(struct pci_dev *down_port, struct pci_dev *up_port, struct margin_link *wrappers,
+                 bool skip_role_check)
 {
   memset(wrappers, 0, sizeof(*wrappers));
-  if (!margin_verify_link(down_port, up_port))
+  if (!margin_verify_link(down_port, up_port, skip_role_check))
     return false;
   wrappers->down_port = fill_dev_wrapper(down_port);
   wrappers->up_port = fill_dev_wrapper(up_port);

--- a/pcilmr.c
+++ b/pcilmr.c
@@ -32,7 +32,7 @@ scan_links(struct pci_access *pacc, bool only_ready)
           struct pci_dev *up = NULL;
           margin_find_pair(pacc, p, &down, &up);
 
-          if (down && margin_verify_link(down, up))
+          if (down && margin_verify_link(down, up, false))
             {
               margin_log_bdfs(down, up);
               if (!only_ready && (margin_check_ready_bit(down) || margin_check_ready_bit(up)))


### PR DESCRIPTION
## Summary
- allow specifying physical slot identifiers such as `slot1` when selecting links to margin
- permit skipping root/endpoint role validation when a slot identifier is used while preserving other link checks

## Testing
- make pcilmr

------
https://chatgpt.com/codex/tasks/task_e_68da27e603d483258335a35d10d3cea5