### PR TITLE
Add --enp option to remote PCI utilities

### DIFF
--- a/lib/remote-socket.c
+++ b/lib/remote-socket.c
@@ -40,6 +40,7 @@ struct remote_ctx
   int bus;
   int slot;
   int func;
+  int rp_enp_flag;
   char slot_id[64];
   int host_auto;
 };
@@ -49,6 +50,7 @@ remote_config(struct pci_access *a)
 {
   pci_define_param(a, "remote.slot", "", "Remote MCU slot specification [<host>[:<port>]@]<slot_number|domain:bus:slot.func>");
   pci_define_param(a, "remote.timeout", "5000", "Remote MCU socket timeout in milliseconds");
+  pci_define_param(a, "remote.enp", "0", "Remote MCU RP ENP flag (0 or 1)");
 }
 
 static int
@@ -228,6 +230,22 @@ remote_parse_timeout(struct remote_ctx *ctx, struct pci_access *a)
 }
 
 static void
+remote_parse_enp(struct remote_ctx *ctx, struct pci_access *a)
+{
+  char *val = pci_get_param(a, "remote.enp");
+  if (val && *val)
+    {
+      char *end;
+      long flag = strtol(val, &end, 0);
+      if (*end || flag < 0 || flag > 1)
+        a->error("Invalid remote ENP flag value: %s", val);
+      ctx->rp_enp_flag = flag;
+    }
+  else
+    ctx->rp_enp_flag = 0;
+}
+
+static void
 remote_init(struct pci_access *a)
 {
   struct remote_ctx *ctx = pci_malloc(a, sizeof(*ctx));
@@ -237,6 +255,7 @@ remote_init(struct pci_access *a)
   const char *spec = pci_get_param(a, "remote.slot");
   remote_parse_slot(ctx, a, spec);
   remote_parse_timeout(ctx, a);
+  remote_parse_enp(ctx, a);
 
   if (ctx->host_auto)
     remote_select_default_host(ctx);
@@ -425,7 +444,7 @@ remote_regaddr(const struct remote_ctx *ctx, unsigned int pos)
 {
   unsigned int flag = (unsigned int) (0x3 & 0xff);  // bit[19:18]
   unsigned int slot = (unsigned int) ((ctx->slot & 0xff) - 1); // bit[17:15]
-  unsigned int rp_enp_flag = (unsigned int) (0); // bit[14]
+  unsigned int rp_enp_flag = ctx->rp_enp_flag ? 1U : 0U; // bit[14]
   unsigned int offset = pos & ~1U; // bit[13:0]
 
   return (flag << 18) | (slot << 15) | (rp_enp_flag << 14) | (offset & 0x3fff);

--- a/lmr/margin_args.c
+++ b/lmr/margin_args.c
@@ -30,6 +30,7 @@ const char *usage
     "--scan\t\t\tScan for Links available for margining\n\n"
     "Margining options (see man for all options):\n\n"
     "Common (for all specified links) options:\n"
+    "--enp[=<0|1>]\tSet remote slot ENP flag when accessing a remote DUT.\n"
     "-c\t\t\tPrint Device Lane Margining Capabilities only. Do not run margining.\n\n"
     "Link specific options:\n"
     "-r <recvn>[,<recvn>...]\tSpecify Receivers to select margining targets.\n"

--- a/lspci.c
+++ b/lspci.c
@@ -39,6 +39,7 @@ static char *opt_remote_slot_spec;
 static char *opt_remote_slot_bdf;
 static struct pci_filter remote_slot_filter;
 static int remote_slot_enabled;
+static char *opt_remote_enp_value;
 
 static void
 consume_remote_slot_option(int *argc, char ***argvp)
@@ -90,6 +91,24 @@ consume_remote_slot_option(int *argc, char ***argvp)
           continue;
         }
 
+      if (!strcmp(arg, "--enp"))
+        {
+          if (opt_remote_enp_value)
+            die("--enp specified multiple times");
+          opt_remote_enp_value = xstrdup("1");
+          continue;
+        }
+
+      if (!strncmp(arg, "--enp=", 6))
+        {
+          if (opt_remote_enp_value)
+            die("--enp specified multiple times");
+          if (!arg[6])
+            die("--enp requires a value when using '=' syntax");
+          opt_remote_enp_value = xstrdup(arg + 6);
+          continue;
+        }
+
       argv[dst++] = arg;
     }
 
@@ -137,6 +156,7 @@ static char help_msg[] =
 #endif
 "-M\t\tEnable `bus mapping' mode (dangerous; root only)\n"
 "--slot [<host>[:<port>]@]<slot>\tAccess remote slot via MCU socket\n"
+"--enp[=<0|1>]\t\tSet remote slot ENP flag (default: enabled when option is present)\n"
 "\n"
 "PCI access options:\n"
 GENERIC_HELP
@@ -1186,6 +1206,12 @@ main(int argc, char **argv)
   pacc = pci_alloc();
   pacc->error = die;
   pci_filter_init(pacc, &filter);
+
+  if (opt_remote_enp_value)
+    {
+      if (pci_set_param(pacc, "remote.enp", opt_remote_enp_value) < 0)
+        die("Unable to configure remote ENP flag");
+    }
 
   if (opt_remote_slot_spec)
     {

--- a/lspci.man
+++ b/lspci.man
@@ -180,6 +180,12 @@ IPv4 assignment: it expects the machine running \fIlspci\fP to own the address
 \fB192.168.<bus>.1<device>\fP and connects to \fB192.168.<bus>.<device>\fP on
 port 4001.
 .TP
+.B --enp[=<0|1>]
+Override the ENP flag that is sent as part of remote register accesses. When
+no value is supplied, the flag is asserted (set to 1). Supplying an explicit
+value allows forcing the flag to either 0 or 1 when communicating with the
+remote management controller.
+.TP
 .B --version
 Shows
 .I lspci

--- a/pcilmr.c
+++ b/pcilmr.c
@@ -22,6 +22,7 @@ configure_remote_backend(struct pci_access *pacc, int argc, char **argv)
 {
   bool skip_next = false;
   struct margin_dut_identifier dut;
+  bool enp_configured = false;
 
   for (int i = 1; i < argc; i++)
     {
@@ -42,6 +43,28 @@ configure_remote_backend(struct pci_access *pacc, int argc, char **argv)
             opt++;
           if (!*opt)
             continue;
+
+          if (!strncmp(opt, "enp", 3))
+            {
+              if (enp_configured)
+                die("--enp specified multiple times");
+              const char *value;
+              if (opt[3] == '=')
+                {
+                  value = opt + 4;
+                  if (!*value)
+                    die("--enp requires a value when using '=' syntax");
+                }
+              else if (!opt[3])
+                value = "1";
+              else
+                die("Unknown option --%s", opt);
+
+              if (pci_set_param(pacc, "remote.enp", (char *) value) < 0)
+                die("Unable to configure remote ENP flag: %s", value);
+              enp_configured = true;
+              continue;
+            }
 
           if (!opt[1] && strchr("eodrlptvg", opt[0]))
             skip_next = true;

--- a/pcilmr.man
+++ b/pcilmr.man
@@ -172,6 +172,11 @@ will generate file with the name in form of
 .RI "\[dq]lmr_" "<port>" "_Rx" # _ <timestamp> ".csv\[dq]"
 for each successfully tested receiver.
 .TP
+.BI --enp "[=<0|1>]"
+Override the ENP flag used for remote register accesses. When the option is
+present without a value the flag is forced to 1. Supplying \fB0\fP or \fB1\fP
+lets you control the exact value sent to the management controller.
+.TP
 .BI -d " <time>"
 Specify dwell time in seconds for the margining step.
 .br

--- a/setpci.c
+++ b/setpci.c
@@ -58,6 +58,7 @@ static char *remote_slot_spec;
 static char *remote_slot_bdf;
 static struct pci_filter remote_slot_filter;
 static int remote_slot_enabled;
+static char *remote_enp_value;
 
 static void
 consume_remote_slot_option(int *argc, char ***argvp)
@@ -106,6 +107,24 @@ consume_remote_slot_option(int *argc, char ***argvp)
             die("--slot requires a device address after '@'");
           remote_slot_bdf = xstrdup(bdf);
 
+          continue;
+        }
+
+      if (!strcmp(arg, "--enp"))
+        {
+          if (remote_enp_value)
+            die("--enp specified multiple times");
+          remote_enp_value = xstrdup("1");
+          continue;
+        }
+
+      if (!strncmp(arg, "--enp=", 6))
+        {
+          if (remote_enp_value)
+            die("--enp specified multiple times");
+          if (!arg[6])
+            die("--enp requires a value when using '=' syntax");
+          remote_enp_value = xstrdup(arg + 6);
           continue;
         }
 
@@ -494,6 +513,7 @@ usage(void)
 "-r\t\tUse raw access without bus scan if possible\n"
 "--dumpregs\tDump all known register names and exit\n"
 "--slot [<host>[:<port>]@]<slot>\tAccess remote slot via MCU socket\n"
+"--enp[=<0|1>]\t\tSet remote slot ENP flag (default: enabled when option is present)\n"
 "\n"
 "PCI access options:\n"
 GENERIC_HELP
@@ -903,6 +923,11 @@ main(int argc, char **argv)
 
   pacc = pci_alloc();
   pacc->error = die;
+  if (remote_enp_value)
+    {
+      if (pci_set_param(pacc, "remote.enp", remote_enp_value) < 0)
+        die("Unable to configure remote ENP flag");
+    }
   if (remote_slot_spec)
     {
       struct pci_filter tmp;

--- a/setpci.man
+++ b/setpci.man
@@ -71,6 +71,11 @@ remote management controller. The slot string must include the complete
 portion is omitted the controller address is derived from the local IPv4
 configuration: \fIsetpci\fP expects to own \fB192.168.<bus>.1<device>\fP and
 will contact \fB192.168.<bus>.<device>\fP on port 4001.
+.TP
+.B --enp[=<0|1>]
+Control the ENP flag used for remote register accesses. Without an explicit
+value the flag is asserted. Providing \fB0\fP or \fB1\fP lets you force a
+specific value when communicating with the remote controller.
 
 .SS PCI access options
 .PP


### PR DESCRIPTION
## Summary
- add a configurable ENP flag to the remote-socket backend
- surface a shared --enp flag across lspci, setpci, and pcilmr with documentation updates

## Testing
- make lspci setpci pcilmr

------
https://chatgpt.com/codex/tasks/task_e_68ede50e03108325b8e80d9797b04d30